### PR TITLE
WeakRef & RefCounted

### DIFF
--- a/memory/BUILD
+++ b/memory/BUILD
@@ -16,6 +16,7 @@ cc_library(
     name = "ref_counted",
     hdrs = [
         "ref_counted.h",
+        "thread_unsafe_ref_control.h",
     ],
     visibility = ["//visibility:public"],
 )

--- a/memory/BUILD
+++ b/memory/BUILD
@@ -39,6 +39,7 @@ cc_test(
     ],
     deps = [
         ":ref_counted",
+        "//common/test_structures:base_types",
         "@com_googletest//:gtest_main",
     ],
 )

--- a/memory/BUILD
+++ b/memory/BUILD
@@ -17,6 +17,7 @@ cc_library(
     hdrs = [
         "ref_counted.h",
         "thread_unsafe_ref_control.h",
+        "weak_ref_counted.h",
     ],
     visibility = ["//visibility:public"],
 )
@@ -36,6 +37,18 @@ cc_test(
     name = "ref_counted_test",
     srcs = [
         "ref_counted_test.cc",
+    ],
+    deps = [
+        ":ref_counted",
+        "//common/test_structures:base_types",
+        "@com_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "weak_ref_counted_test",
+    srcs = [
+        "weak_ref_counted_test.cc",
     ],
     deps = [
         ":ref_counted",

--- a/memory/ref_counted_test.cc
+++ b/memory/ref_counted_test.cc
@@ -1,107 +1,19 @@
 #include "common/memory/ref_counted.h"
 
 #include <cstdint>
-#include <iostream>
 #include <utility>
 
 #include "gtest/gtest.h"
 
+#include "common/test_structures/base_types.h"
+
 namespace common {
 
-namespace {
-
-struct Base {
-  virtual ~Base() = default;
-};
-
-struct NonCopyMovable : public Base {
-  NonCopyMovable(std::size_t value, std::size_t* destructor_count = nullptr)
-      : value_(value), destructor_count_(destructor_count) {
-    if (destructor_count_ != nullptr) {
-      *destructor_count_ = 0;
-    }
-  }
-
-  ~NonCopyMovable() override {
-    if (destructor_count_ != nullptr) {
-      ++(*destructor_count_);
-    }
-  }
-
-  NonCopyMovable(const NonCopyMovable&) = delete;
-  NonCopyMovable& operator=(const NonCopyMovable&) = delete;
-
-  std::size_t value_;
-  std::size_t* const destructor_count_;
-};
-
-struct Movable : public Base {
-  Movable(std::size_t value, std::size_t* destructor_count = nullptr)
-      : value_(value), destructor_count_(destructor_count) {
-    if (destructor_count_ != nullptr) {
-      *destructor_count_ = 0;
-    }
-  }
-
-  ~Movable() override {
-    if (destructor_count_ != nullptr) {
-      ++(*destructor_count_);
-    }
-  }
-
-  Movable(const Movable&) = delete;
-  Movable(Movable&&) = default;
-
-  Movable& operator=(const Movable&) = delete;
-  Movable& operator=(Movable&&) = default;
-
-  std::size_t value_;
-  std::size_t* const destructor_count_;
-};
-
-struct Copyable : public Base {
-  Copyable(std::size_t value, std::size_t* destructor_count = nullptr)
-      : value_(value), destructor_count_(destructor_count) {
-    if (destructor_count_ != nullptr) {
-      *destructor_count_ = 0;
-    }
-  }
-
-  ~Copyable() override {
-    if (destructor_count_ != nullptr) {
-      ++(*destructor_count_);
-    }
-  }
-
-  Copyable(const Copyable&) = default;
-  Copyable(Copyable&&) = delete;
-
-  Copyable& operator=(const Copyable&) = default;
-  Copyable& operator=(Copyable&&) = delete;
-
-  std::size_t value_;
-  std::size_t* const destructor_count_;
-};
-
-struct CopyMovable : public Base {
-  CopyMovable(std::size_t value, std::size_t* destructor_count = nullptr)
-      : value_(value), destructor_count_(destructor_count) {
-    if (destructor_count_ != nullptr) {
-      *destructor_count_ = 0;
-    }
-  }
-
-  ~CopyMovable() override {
-    if (destructor_count_ != nullptr) {
-      ++(*destructor_count_);
-    }
-  }
-
-  std::size_t value_;
-  std::size_t* const destructor_count_;
-};
-
-}  // namespace
+using test_structures::Base;
+using test_structures::NonCopyMovable;
+using test_structures::Movable;
+using test_structures::Copyable;
+using test_structures::CopyMovable;
 
 template <typename T>
 struct RefCountedTest : public testing::Test {

--- a/memory/thread_unsafe_ref_control.h
+++ b/memory/thread_unsafe_ref_control.h
@@ -11,7 +11,7 @@ namespace common {
 class ThreadUnsafeRefControl {
  public:
   ThreadUnsafeRefControl(std::size_t use_count)
-      : use_count_(use_count), weak_count_(use_count_ != 0) {}
+      : use_count_(use_count), weak_count_(0) {}
 
   // ThreadUnsafeRefControl is not copy / move constructible / assignable
   ThreadUnsafeRefControl(const ThreadUnsafeRefControl&) = delete;
@@ -34,7 +34,7 @@ class ThreadUnsafeRefControl {
   /// @return  the updated reference / use count
   // Note: in case of an underflow the reference count will not be updated
   std::size_t DecrementUseCount() {
-    return (use_count_ > 0 ? --use_count_ : use_count_);
+    return (use_count_ > 0u ? --use_count_ : use_count_);
   }
 
   /// Increases the weak reference count

--- a/memory/thread_unsafe_ref_control.h
+++ b/memory/thread_unsafe_ref_control.h
@@ -1,0 +1,67 @@
+#ifndef COMMON_MEMORY_REF_COUNT_CONTROL_H_
+#define COMMON_MEMORY_REF_COUNT_CONTROL_H_
+
+#include <cstdint>
+#include <limits>
+
+namespace common {
+
+/// @class ThreadUnsafeRefControl
+/// A thread unsafe control block for reference counting
+class ThreadUnsafeRefControl {
+ public:
+  ThreadUnsafeRefControl(std::size_t use_count)
+      : use_count_(use_count), weak_count_(use_count_ != 0) {}
+
+  // ThreadUnsafeRefControl is not copy / move constructible / assignable
+  ThreadUnsafeRefControl(const ThreadUnsafeRefControl&) = delete;
+  ThreadUnsafeRefControl& operator=(const ThreadUnsafeRefControl) = delete;
+
+  /// @return  current reference / use count
+  std::size_t UseCount() const { return use_count_; }
+
+  /// @return  current count of weak references
+  std::size_t WeakCount() const { return weak_count_; }
+
+  /// Increases the reference / use count
+  /// @return  the updated reference / use count
+  // Note: in case of an overfow the reference count will not be updated
+  std::size_t IncrementUseCount() {
+    return (use_count_ < kCountMax ? ++use_count_ : use_count_);
+  }
+
+  /// Decreases the reference / use count
+  /// @return  the updated reference / use count
+  // Note: in case of an underflow the reference count will not be updated
+  std::size_t DecrementUseCount() {
+    return (use_count_ > 0 ? --use_count_ : use_count_);
+  }
+
+  /// Increases the weak reference count
+  /// @return  updated value fo the weak reference count
+  std::size_t IncrementWeakCount() {
+    return (weak_count_ < kCountMax ? ++weak_count_ : weak_count_);
+  }
+
+  /// Decreases the weak reference count
+  /// @return  updated value fo the weak reference count
+  std::size_t DecrementWeakCount() {
+    return (weak_count_ > 0 ? --weak_count_ : weak_count_);
+  }
+
+  /// Sets the value of the reference / use count
+  void SetUseCount(std::size_t use_count) { use_count_ = use_count; }
+
+  /// Sets the value fo the weak reference count
+  void SetWeakCount(std::size_t weak_count) { weak_count_ = weak_count; }
+
+ private:
+  constexpr static std::size_t kCountMax =
+      std::numeric_limits<std::size_t>::max();
+  std::size_t use_count_;
+  std::size_t weak_count_;
+};
+
+}  // namespace common
+
+#endif  // COMMON_MEMORY_REF_COUNT_CONTROL_H_

--- a/memory/weak_ref_counted.h
+++ b/memory/weak_ref_counted.h
@@ -1,0 +1,80 @@
+#ifndef COMMON_MEMORY_WEAK_REF_COUNTED_H_
+#define COMMON_MEMORY_WEAK_REF_COUNTED_H_
+
+#include <type_traits>
+
+#include "common/memory/thread_unsafe_ref_control.h"
+
+namespace common {
+
+template <typename T, typename Control = ThreadUnsafeRefControl>
+class WeakRefCounted {
+ public:
+  WeakRefCounted() : WeakRefCounted(nullptr, nullptr) {}
+
+  template <typename U,
+            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
+  WeakRefCounted(const WeakRefCounted<U, Control>& other)
+      : WeakRefCounted(other.control_ptr_, other.managed_) {
+    if (this->control_ptr_ != nullptr) {
+      this->control_ptr_->IncrementWeakCount();
+    }
+  }
+
+  template <typename U,
+            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
+  WeakRefCounted(WeakRefCounted<U, Control>&& other)
+      : WeakRefCounted(other.control_ptr_, other.managed_) {
+    other.control_ptr_ = nullptr;
+    other.managed_ = nullptr;
+  }
+
+  template <typename U,
+            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
+  WeakRefCounted& operator=(const WeakRefCounted<U, Control>& other) {
+    if (this->control_ptr_ != nullptr) {
+      if (this->control_ptr_->WeakCount() == 1) {
+        DestroyControl();
+      } else {
+        this->control_ptr_->DecrementWeakCount();
+      }
+    }
+    this->control_ptr_ = other->control_ptr_;
+    this->managed_ = other->managed_;
+    if (this->control_ptr_ != nullptr) {
+      this->control_ptr_->IncrementWeakCount();
+    }
+  }
+
+  template <typename U,
+            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
+  WeakRefCounted& operator=(WeakRefCounted<U, Control>&& other) {
+    this->control_ptr_ = other->control_ptr_;
+    this->managed_ = other->managed_;
+    other.control_ptr_ = nullptr;
+    other.managed_ = nullptr;
+  }
+
+  bool HasWeakRef() const {
+    return (control_ptr_ == nullptr) || (control_ptr_->UseCount() == 0);
+  }
+
+ private:
+  template <typename U, typename UCounter>
+  friend class WeakRefCounted;
+
+  template <typename U, typename UCounter>
+  friend class RefCounted;
+
+  WeakRefCounted(Control* control_ptr, T* to_manage)
+      : control_ptr_(control_ptr), managed_(to_manage) {}
+
+  void DestroyControl() { delete control_ptr_; }
+
+  Control* control_ptr_;
+  T* managed_;
+};
+
+}  // namespace common
+
+#endif  // COMMON_MEMORY_WEAK_REF_COUNTED_H_

--- a/memory/weak_ref_counted.h
+++ b/memory/weak_ref_counted.h
@@ -1,7 +1,6 @@
 #ifndef COMMON_MEMORY_WEAK_REF_COUNTED_H_
 #define COMMON_MEMORY_WEAK_REF_COUNTED_H_
 
-#include <iostream>
 #include <type_traits>
 #include "common/memory/thread_unsafe_ref_control.h"
 
@@ -12,70 +11,69 @@ class WeakRefCounted {
  public:
   WeakRefCounted() : WeakRefCounted(nullptr, nullptr) {}
 
-  template <typename U,
-            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
-  WeakRefCounted(const WeakRefCounted<U, Control>& other)
+  template <typename U, typename = typename std::enable_if<
+                            std::is_same<U, T>::value ||
+                            std::is_convertible<U*, T*>::value>::type>
+  WeakRefCounted(WeakRefCounted<U, Control>& other)
       : WeakRefCounted(other.control_ptr_, other.managed_) {
-    std::cout << "Copy construction" << std::endl;
     if (this->control_ptr_ != nullptr) {
       this->control_ptr_->IncrementWeakCount();
     }
   }
 
-  template <typename U,
-            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
+  template <typename U, typename = typename std::enable_if<
+                            std::is_convertible<U*, T*>::value>::type>
   WeakRefCounted(WeakRefCounted<U, Control>&& other)
       : WeakRefCounted(other.control_ptr_, other.managed_) {
-    std::cout << "Move construction" << std::endl;
     other.control_ptr_ = nullptr;
     other.managed_ = nullptr;
   }
 
   ~WeakRefCounted() {
-    std::cout << "================~WeakRefCounted================" << std::endl;
-    std::cout << "WeakCount: " << WeakCount() << std::endl;
     if (control_ptr_ != nullptr) {
-      if (control_ptr_->WeakCount() == 1u) {
-        std::cout << "destroy control_ptr_" << std::endl;
+      if (control_ptr_->WeakCount() == 1u && control_ptr_->UseCount() == 0u) {
         DestroyControl();
       } else {
-        std::cout << "Decrement weak count" << std::endl;
         control_ptr_->DecrementWeakCount();
       }
     }
-    std::cout << "================~WeakRefCounted================" << std::endl;
   }
 
-  template <typename U,
-            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
-  WeakRefCounted& operator=(const WeakRefCounted<U, Control>& other) {
-    std::cout << "Copy assignment" << std::endl;
+  template <typename U, typename = typename std::enable_if<
+                            std::is_convertible<U*, T*>::value>::type>
+  WeakRefCounted& operator=(WeakRefCounted<U, Control>& other) {
     if (this->control_ptr_ != nullptr) {
-      if (this->control_ptr_->WeakCount() == 1u) {
+      if (this->control_ptr_->WeakCount() == 1u &&
+          this->control_ptr_->UseCount() == 0u) {
         DestroyControl();
       } else {
         this->control_ptr_->DecrementWeakCount();
       }
     }
-    this->control_ptr_ = other->control_ptr_;
-    this->managed_ = other->managed_;
+    this->control_ptr_ = other.control_ptr_;
+    this->managed_ = other.managed_;
     if (this->control_ptr_ != nullptr) {
       this->control_ptr_->IncrementWeakCount();
     }
+    return *this;
   }
 
-  template <typename U,
-            typename = std::enable_if<std::is_convertible<U*, T*>::value>>
+  template <typename U, typename = typename std::enable_if<
+                            std::is_convertible<U*, T*>::value>::type>
   WeakRefCounted& operator=(WeakRefCounted<U, Control>&& other) {
-    std::cout << "Move assignment" << std::endl;
-    this->control_ptr_ = other->control_ptr_;
-    this->managed_ = other->managed_;
+    this->control_ptr_ = other.control_ptr_;
+    this->managed_ = other.managed_;
     other.control_ptr_ = nullptr;
     other.managed_ = nullptr;
+    return *this;
   }
 
   bool HasWeakRef() const {
     return (control_ptr_ != nullptr) && (control_ptr_->UseCount() != 0);
+  }
+
+  std::size_t UseCount() const {
+    return this->control_ptr_ == nullptr ? 0u : this->control_ptr_->UseCount();
   }
 
   std::size_t WeakCount() const {
@@ -92,7 +90,10 @@ class WeakRefCounted {
   WeakRefCounted(Control* control_ptr, T* to_manage)
       : control_ptr_(control_ptr), managed_(to_manage) {}
 
-  void DestroyControl() { delete control_ptr_; }
+  void DestroyControl() {
+    delete control_ptr_;
+    control_ptr_ = nullptr;
+  }
 
   Control* control_ptr_;
   T* managed_;

--- a/memory/weak_ref_counted_test.cc
+++ b/memory/weak_ref_counted_test.cc
@@ -1,7 +1,10 @@
 #include "common/memory/weak_ref_counted.h"
 
+#include <utility>
+
 #include "gtest/gtest.h"
 
+#include "common/memory/ref_counted.h"
 #include "common/test_structures/base_types.h"
 
 namespace common {
@@ -17,14 +20,65 @@ struct WeakRefCountedTest : public testing::Test {
   using ParamType = T;
 };
 
-using TestTypes =
-    testing::Types<NonCopyMovable, Movable, Copyable, CopyMovable>;
+// using TestTypes =
+//     testing::Types<NonCopyMovable, Movable, Copyable, CopyMovable>;
+
+using TestTypes = testing::Types<NonCopyMovable>;
 
 TYPED_TEST_SUITE(WeakRefCountedTest, TestTypes);
 
 TYPED_TEST(WeakRefCountedTest, ConstructDestructTest) {
   WeakRefCounted<TypeParam> test_object;
-  EXPECT_TRUE(test_object.HasWeakRef());
+  EXPECT_FALSE(test_object.HasWeakRef());
+}
+
+TYPED_TEST(WeakRefCountedTest, WeakRefCreationTest) {
+  RefCounted<TypeParam> obj(new TypeParam(12));
+  EXPECT_EQ(obj.UseCount(), 1u);
+  EXPECT_EQ(obj.WeakCount(), 1u);
+  {
+    WeakRefCounted<TypeParam> weak_ref = obj.GetWeakRef();
+    EXPECT_EQ(obj.UseCount(), 1u);
+    EXPECT_EQ(obj.WeakCount(), 2u);
+    EXPECT_EQ(weak_ref.WeakCount(), 2u);
+
+    EXPECT_EQ(obj.UseCount(), 1u);
+    EXPECT_EQ(obj.WeakCount(), 2u);
+    EXPECT_EQ(weak_ref.WeakCount(), 2u);
+  }
+  EXPECT_EQ(obj.UseCount(), 1u);
+  EXPECT_EQ(obj.WeakCount(), 1u);
+}
+
+TYPED_TEST(WeakRefCountedTest, CopyConstructionTest) {
+  RefCounted<TypeParam> obj(new TypeParam(12));
+  EXPECT_EQ(obj.UseCount(), 1u);
+  EXPECT_EQ(obj.WeakCount(), 1u);
+
+  const WeakRefCounted<TypeParam> weak_ref = obj.GetWeakRef();
+  EXPECT_EQ(obj.UseCount(), 1u);
+  EXPECT_EQ(obj.WeakCount(), 2u);
+  EXPECT_EQ(weak_ref.WeakCount(), 2u);
+
+  std::cout << "Constructing" << std::endl;
+  WeakRefCounted<TypeParam> another_weak_ref(weak_ref);
+  std::cout << "Done" << std::endl;
+  EXPECT_EQ(obj.UseCount(), 1u);
+  EXPECT_EQ(obj.WeakCount(), 3u);
+  EXPECT_EQ(weak_ref.WeakCount(), 3u);
+  EXPECT_EQ(another_weak_ref.WeakCount(), 3u);
+}
+
+TYPED_TEST(WeakRefCountedTest, ExpirationTest) {
+  RefCounted<TypeParam> obj(new TypeParam(12));
+  {
+    RefCounted<TypeParam> moved_obj(std::move(obj));
+    WeakRefCounted<TypeParam> weak_ref = moved_obj.GetWeakRef();
+    EXPECT_EQ(moved_obj.UseCount(), 1u);
+    EXPECT_EQ(moved_obj.WeakCount(), 2u);
+    EXPECT_EQ(weak_ref.WeakCount(), 2u);
+  }
+  EXPECT_EQ(obj.UseCount(), 0u);
 }
 
 }  // namespace common

--- a/memory/weak_ref_counted_test.cc
+++ b/memory/weak_ref_counted_test.cc
@@ -1,0 +1,30 @@
+#include "common/memory/weak_ref_counted.h"
+
+#include "gtest/gtest.h"
+
+#include "common/test_structures/base_types.h"
+
+namespace common {
+
+using test_structures::Base;
+using test_structures::NonCopyMovable;
+using test_structures::Movable;
+using test_structures::Copyable;
+using test_structures::CopyMovable;
+
+template <typename T>
+struct WeakRefCountedTest : public testing::Test {
+  using ParamType = T;
+};
+
+using TestTypes =
+    testing::Types<NonCopyMovable, Movable, Copyable, CopyMovable>;
+
+TYPED_TEST_SUITE(WeakRefCountedTest, TestTypes);
+
+TYPED_TEST(WeakRefCountedTest, ConstructDestructTest) {
+  WeakRefCounted<TypeParam> test_object;
+  EXPECT_TRUE(test_object.HasWeakRef());
+}
+
+}  // namespace common

--- a/test_structures/BUILD
+++ b/test_structures/BUILD
@@ -1,0 +1,14 @@
+package(
+    default_visibility = ["//visibility:private"],
+    default_testonly = True,
+)
+
+licenses(["notice"])
+
+cc_library(
+    name = "base_types",
+    hdrs = [
+        "base_types.h",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/test_structures/base_types.h
+++ b/test_structures/base_types.h
@@ -1,0 +1,103 @@
+#ifndef COMMON_TEST_STRUCTURES_BASE_TYPES_H_
+#define COMMON_TEST_STRUCTURES_BASE_TYPES_H_
+
+#include <cstdint>
+
+namespace common {
+namespace test_structures {
+
+struct Base {
+  virtual ~Base() = default;
+};
+
+struct NonCopyMovable : public Base {
+  NonCopyMovable(std::size_t value, std::size_t* destructor_count = nullptr)
+      : value_(value), destructor_count_(destructor_count) {
+    if (destructor_count_ != nullptr) {
+      *destructor_count_ = 0;
+    }
+  }
+
+  ~NonCopyMovable() override {
+    if (destructor_count_ != nullptr) {
+      ++(*destructor_count_);
+    }
+  }
+
+  NonCopyMovable(const NonCopyMovable&) = delete;
+  NonCopyMovable& operator=(const NonCopyMovable&) = delete;
+
+  std::size_t value_;
+  std::size_t* const destructor_count_;
+};
+
+struct Movable : public Base {
+  Movable(std::size_t value, std::size_t* destructor_count = nullptr)
+      : value_(value), destructor_count_(destructor_count) {
+    if (destructor_count_ != nullptr) {
+      *destructor_count_ = 0;
+    }
+  }
+
+  ~Movable() override {
+    if (destructor_count_ != nullptr) {
+      ++(*destructor_count_);
+    }
+  }
+
+  Movable(const Movable&) = delete;
+  Movable(Movable&&) = default;
+
+  Movable& operator=(const Movable&) = delete;
+  Movable& operator=(Movable&&) = default;
+
+  std::size_t value_;
+  std::size_t* const destructor_count_;
+};
+
+struct Copyable : public Base {
+  Copyable(std::size_t value, std::size_t* destructor_count = nullptr)
+      : value_(value), destructor_count_(destructor_count) {
+    if (destructor_count_ != nullptr) {
+      *destructor_count_ = 0;
+    }
+  }
+
+  ~Copyable() override {
+    if (destructor_count_ != nullptr) {
+      ++(*destructor_count_);
+    }
+  }
+
+  Copyable(const Copyable&) = default;
+  Copyable(Copyable&&) = delete;
+
+  Copyable& operator=(const Copyable&) = default;
+  Copyable& operator=(Copyable&&) = delete;
+
+  std::size_t value_;
+  std::size_t* const destructor_count_;
+};
+
+struct CopyMovable : public Base {
+  CopyMovable(std::size_t value, std::size_t* destructor_count = nullptr)
+      : value_(value), destructor_count_(destructor_count) {
+    if (destructor_count_ != nullptr) {
+      *destructor_count_ = 0;
+    }
+  }
+
+  ~CopyMovable() override {
+    if (destructor_count_ != nullptr) {
+      ++(*destructor_count_);
+    }
+  }
+
+  std::size_t value_;
+  std::size_t* const destructor_count_;
+};
+
+}  // namespace test_structures
+}  // namespace common
+
+#endif  // COMMON_TEST_STRUCTURES_BASE_TYPES_H_


### PR DESCRIPTION
Implement WeakRef & RefCounted

- Provides an cheaper alternative to std::shared_ptr & std::weak_ptr without the overhead of atomic operations
- Basic implementation which probably needs some additional unit tests and some edge case coverage

